### PR TITLE
Use Git dependency instead of path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ path = "src/lib.rs"
 crate-type = ["staticlib"]
 
 [dependencies.libc]
-path = "../libc"
+git = "https://github.com/Meziu/libc.git"


### PR DESCRIPTION
This makes using the crate much easier.