### PR TITLE
Handle the null case in realpath

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,15 @@ extern "C" fn posix_memalign(
 #[no_mangle]
 unsafe extern "C" fn realpath(
     path: *const libc::c_char,
-    resolved_path: *mut libc::c_char,
+    mut resolved_path: *mut libc::c_char,
 ) -> *mut libc::c_char {
-    libc::memcpy(resolved_path as _, path as _, libc::strlen(path));
+    let path_len = libc::strlen(path);
+
+    if resolved_path.is_null() {
+        resolved_path = libc::malloc(path_len + 1) as _;
+    }
+
+    libc::strncpy(resolved_path as _, path as _, path_len + 1);
 
     resolved_path
 }


### PR DESCRIPTION
The destination pointer might be null, in which case we are supposed to malloc some memory for it:
https://man7.org/linux/man-pages/man3/realpath.3.html

This is the realpath I was using to try and fix https://github.com/Meziu/ctru-rs/pull/14, but I didn't make a PR for it until now.