### PR TITLE
Add clock_gettime implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ unsafe extern "C" fn clock_gettime(
             retval = libc::gettimeofday(tv.as_mut_ptr(), ptr::null_mut());
             if retval == 0 {
                 let tv = tv.assume_init();
-                (*tp).tv_nsec = (tv.tv_usec * 1000).into();
+                (*tp).tv_nsec = tv.tv_usec * 1000;
                 (*tp).tv_sec = tv.tv_sec;
             }
         }


### PR DESCRIPTION
This is necessary in order to use common implementations of time that rely on `libc::clock_gettime`.