### PR TITLE
Add getrandom impl using ctru_sys bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ license = "MIT/Apache 2.0"
 edition = "2018"
 
 [dependencies]
+ctru-sys = { git = "https://github.com/Meziu/ctru-rs.git" }
 libc = "0.2.116"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,3 +67,19 @@ unsafe extern "C" fn clock_gettime(
 
     retval
 }
+
+#[no_mangle]
+unsafe extern "C" fn getrandom(
+    buf: *mut libc::c_void,
+    buflen: libc::size_t,
+    _flags: libc::c_uint,
+) -> libc::ssize_t {
+    let ret = ctru_sys::psInit();
+    if ret != 0 {
+        return ret.try_into().unwrap();
+    }
+
+    ctru_sys::PS_GenerateRandomBytes(buf, buflen.try_into().unwrap())
+        .try_into()
+        .unwrap()
+}


### PR DESCRIPTION
Ref https://github.com/Meziu/rust-horizon/issues/6

Add a `getrandom` call that `libc` can link against. This will also require a change to `libc` to declare an `extern "C" fn getrandom` and then finally update `std` to utilize that call when `target_os = "horizon"`.

Two main questions: 
* Is this the right place to put this impl? we could put it in `ctru-sys` instead if we wanted, but putting it here feels like a "linker-fix" to me. It does require adding the dependency on `ctru-sys`, though.
* How do we want to handle conversion errors? `try_into().unwrap()` feels a bit heavy-handed, maybe if the conversion fails we should set `errno` or something? Does `ctru-sys` have an API for something like `errno` for us to set in case of non-zero return values from the `PS_` syscall?

@Meziu @AzureMarker 