### PR TITLE
Update to upstream libc and fix some clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linker-fix-3ds"
-authors = [ "Andrea Ciliberti <meziu210@icloud.com>" ]
+authors = ["Andrea Ciliberti <meziu210@icloud.com>"]
 version = "0.1.0"
 license = "MIT/Apache 2.0"
 edition = "2018"
 
 [dependencies]
 ctru-sys = { git = "https://github.com/Meziu/ctru-rs.git" }
-libc = { git = "https://github.com/Meziu/libc.git" }
+libc = "0.2.126"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ const ECTRU: libc::c_int = -1;
 /// Call this somewhere to force Rust to link this module.
 /// The call doesn't need to execute, just exist.
 ///
-/// See https://github.com/rust-lang/rust/issues/47384
+/// See <https://github.com/rust-lang/rust/issues/47384>
 pub fn init() {}
 
 extern "C" {
@@ -20,14 +20,12 @@ extern "C" {
 }
 
 #[no_mangle]
-pub extern "C" fn posix_memalign(
+pub unsafe extern "C" fn posix_memalign(
     memptr: *mut *mut libc::c_void,
     align: libc::size_t,
     size: libc::size_t,
 ) -> libc::c_int {
-    unsafe {
-        *memptr = libc::memalign(align, size);
-    }
+    *memptr = libc::memalign(align, size);
 
     0
 }


### PR DESCRIPTION
I still didn't add any `# Safety` docs which was the last clippy lint left here.